### PR TITLE
- fix expect script used for signing rpm's

### DIFF
--- a/package/yast2-add-on-creator.changes
+++ b/package/yast2-add-on-creator.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 31 16:31:36 CET 2014 - jsuchome@suse.cz
+
+- fix expect script used for signing rpm's
+- generate MD5SUM files after signing packages (bnc#485825)
+- 3.1.1
+
+-------------------------------------------------------------------
 Wed Sep 18 10:03:10 UTC 2013 - lslezak@suse.cz
 
 - do not use *.spec.in template, use *.spec file with RPM macros

--- a/package/yast2-add-on-creator.spec
+++ b/package/yast2-add-on-creator.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-add-on-creator
-Version:        3.1.0
+Version:        3.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AddOnCreator.rb
+++ b/src/modules/AddOnCreator.rb
@@ -634,7 +634,7 @@ module Yast
         "\teof {}\n" +
         "    }\n" +
         "    spawn -noecho rpm --define \"_signature gpg\" --define \"_gpg_name %1\" --define \"_gpgbin /usr/bin/gpg\" --resign $rpm\n" +
-        "    expect \"pass phrase:\" {send \"%2 \"}\n" +
+        "    expect \"pass phrase:\" {send \"%2\r\"}\n" +
         "    expect {\n" +
         "\t\"is good.\" {send \"\n" +
         "\"}\n" +
@@ -4036,8 +4036,6 @@ module Yast
         Progress.NextStage
 
         GenerateArchiveFiles(base_output_path)
-
-        CreateMD5SUMS(base_output_path)
       end
 
       Progress.NextStage
@@ -4054,6 +4052,8 @@ module Yast
         )
         return false
       end
+
+      CreateMD5SUMS(base_output_path)
 
       CreateDirectoryYaSTFiles(base_output_path)
 


### PR DESCRIPTION
- generate MD5SUM files after signing packages (bnc#485825)
- 3.1.1
